### PR TITLE
Remove unnecessary linker and rustflags configuration from CI workflow

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -276,9 +276,6 @@ jobs:
         run: |
           echo '[registries.crates-io]' >> .cargo/config.toml
           echo 'protocol = "sparse"' >> .cargo/config.toml
-          echo '[target.x86_64-unknown-linux-gnu]' >> .cargo/config.toml
-          echo 'linker = "clang"' >> .cargo/config.toml
-          echo 'rustflags = ["-C", "link-arg=-fuse-ld=lld"]' >> .cargo/config.toml
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Eliminate redundant linker and rustflags settings from the CI configuration to streamline the workflow.