### PR TITLE
Add splash screen functionality and fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "aseprite-loader"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011a4d9f839a18ab05c84c3688222e4dfae12003bd3e6408a9882f190659994c"
+dependencies = [
+ "bitflags 2.9.0",
+ "flate2",
+ "itertools 0.13.0",
+ "nom",
+ "strum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +523,18 @@ dependencies = [
  "downcast-rs",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "bevy_aseprite_ultra"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe5ac2d20e051bd06e2f7e3cc06bfe9c8c84fc0c8eb79e68e65ffee21912e7f"
+dependencies = [
+ "aseprite-loader",
+ "bevy",
+ "thiserror 2.0.12",
+ "uuid",
 ]
 
 [[package]]
@@ -3229,6 +3255,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy-inspector-egui",
+ "bevy_aseprite_ultra",
  "bevy_ecs_ldtk",
  "bevy_kira_audio",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ bevy_ecs_ldtk = "0.11"
 bevy-inspector-egui = "0.30"
 pathfinding = "4.3.0"
 bevy_kira_audio =  { version = "0.22", features = ["mp3"] }
+bevy_aseprite_ultra = { version = "0.4.1" }
 
 [build-dependencies]
 winres = "0.1"

--- a/assets/splashscreen1.aseprite
+++ b/assets/splashscreen1.aseprite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:235c2e700041a5f1312c202c4c2b2740012224ed5aa39c828541744d1daaf6f3
+size 59391

--- a/assets/splashscreen1.aseprite
+++ b/assets/splashscreen1.aseprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:235c2e700041a5f1312c202c4c2b2740012224ed5aa39c828541744d1daaf6f3
-size 59391
+oid sha256:29dafe114ce1b41a5a9689e96ce4a49a2bf1aab473a703ae2f1442afab77368e
+size 62299

--- a/assets/splashscreen1.gif
+++ b/assets/splashscreen1.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1086b591d4bfac32f0b1849d31a22d52b451817f3fe0c6ad8ce6376659221750
+size 17179

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,6 +1,7 @@
 use bevy::app::{App, Plugin};
 use bevy::input::common_conditions::input_toggle_active;
 use bevy::prelude::KeyCode;
+use bevy_aseprite_ultra::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
@@ -24,6 +25,7 @@ impl Plugin for RtsPlugin {
             .add_plugins(
                 WorldInspectorPlugin::new().run_if(input_toggle_active(false, KeyCode::F10)),
             )
+            .add_plugins(AsepriteUltraPlugin)
             .add_plugins(EntitiesPlugin)
             .add_plugins(MovementPlugin)
             .add_plugins(ResourceGatheringPlugin)

--- a/src/systems/scene.rs
+++ b/src/systems/scene.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy_aseprite_ultra::prelude::*;
 use bevy_ecs_ldtk::prelude::*;
 
 pub struct ScenePlugin;
@@ -6,12 +7,18 @@ pub struct ScenePlugin;
 #[derive(Resource)]
 struct SplashTimer(Timer);
 
+#[derive(Resource, Default)]
+struct MapLoadState {
+    requested: bool,
+}
+
 impl Plugin for ScenePlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(LevelSelection::index(0))
             .insert_resource(LdtkSettings {
                 ..Default::default()
             })
+            .init_resource::<MapLoadState>()
             .add_systems(Startup, setup_scene)
             .add_systems(Update, splash_screen_system);
     }
@@ -26,15 +33,17 @@ pub fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Camera
     commands.spawn((Camera2d, Transform::from_xyz(4000.0, 3000.0, 0.0)));
 
-    // Splash screen
-    let splash_handle: Handle<Image> = asset_server.load("splashscreen1.gif");
+    // animations in bevy ui
     commands.spawn((
-        Sprite {
-            custom_size: Some(Vec2::ZERO),
-            image: splash_handle,
+        SplashScreen,
+        Node {
+            justify_content: JustifyContent::Center,
             ..default()
         },
-        SplashScreen,
+        AseUiAnimation {
+            aseprite: asset_server.load("splashscreen1.aseprite"),
+            animation: Animation::default(),
+        },
     ));
 
     // Insert a timer resource for splash duration (e.g., 3 seconds)
@@ -48,18 +57,30 @@ fn splash_screen_system(
     time: Res<Time>,
     mut timer: ResMut<SplashTimer>,
     asset_server: Res<AssetServer>,
-    mut splash_query: Query<Entity, With<SplashScreen>>,
-    mut has_loaded_map: Local<bool>,
+    splash_query: Query<Entity, With<SplashScreen>>,
+    mut level_events: EventReader<LevelEvent>,
+    mut map_state: ResMut<MapLoadState>,
 ) {
     timer.0.tick(time.delta());
 
-    if timer.0.finished() && !*has_loaded_map {
-        // Despawn splash screen
-        for entity in splash_query.iter_mut() {
-            commands.entity(entity).despawn_recursive();
+    // Process any level events that indicate our level is fully loaded
+    for event in level_events.read() {
+        match event {
+            // This matches when a level has been completely spawned
+            LevelEvent::Spawned(_) => {
+                if map_state.requested {
+                    info!("Level fully loaded, despawning splash screen...");
+                    for entity in splash_query.iter() {
+                        commands.entity(entity).despawn_recursive();
+                    }
+                }
+            }
+            _ => {} // Ignore other level events
         }
+    }
 
-        // Load LDtk map
+    // If timer is finished but map hasn't been requested yet, request the map
+    if timer.0.finished() && !map_state.requested {
         info!("Loading LDtk map: test-map.ldtk");
         let map_handle = asset_server.load("test-map.ldtk");
         info!("Map handle created: {:?}", map_handle);
@@ -69,7 +90,7 @@ fn splash_screen_system(
             ..Default::default()
         });
 
-        info!("Scene setup complete.");
-        *has_loaded_map = true;
+        map_state.requested = true;
+        // The splash screen will now stay visible until the level is loaded
     }
 }

--- a/src/systems/scene.rs
+++ b/src/systems/scene.rs
@@ -3,31 +3,73 @@ use bevy_ecs_ldtk::prelude::*;
 
 pub struct ScenePlugin;
 
+#[derive(Resource)]
+struct SplashTimer(Timer);
+
 impl Plugin for ScenePlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(LevelSelection::index(0))
             .insert_resource(LdtkSettings {
                 ..Default::default()
             })
-            .add_systems(Startup, setup_scene);
+            .add_systems(Startup, setup_scene)
+            .add_systems(Update, splash_screen_system);
     }
 }
 
-pub fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
-    info!("Setting up scene..."); // Log start
+#[derive(Component)]
+struct SplashScreen;
 
-    // Position the camera above the house area where the worker and warrior start
-    // Using coordinates based on your map layout - adjust as needed for your specific map
+pub fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
+    info!("Setting up scene...");
+
+    // Camera
     commands.spawn((Camera2d, Transform::from_xyz(4000.0, 3000.0, 0.0)));
 
-    info!("Loading LDtk map: test-map.ldtk"); // Log before loading
-    let map_handle = asset_server.load("test-map.ldtk");
-    info!("Map handle created: {:?}", map_handle); // Log after loading
+    // Splash screen
+    let splash_handle: Handle<Image> = asset_server.load("splashscreen1.gif");
+    commands.spawn((
+        Sprite {
+            custom_size: Some(Vec2::ZERO),
+            image: splash_handle,
+            ..default()
+        },
+        SplashScreen,
+    ));
 
-    commands.spawn(LdtkWorldBundle {
-        ldtk_handle: map_handle.into(),
-        ..Default::default()
-    });
+    // Insert a timer resource for splash duration (e.g., 3 seconds)
+    commands.insert_resource(SplashTimer(Timer::from_seconds(3.0, TimerMode::Once)));
 
-    info!("Scene setup complete."); // Log end
+    info!("Splash screen spawned, waiting before loading map...");
+}
+
+fn splash_screen_system(
+    mut commands: Commands,
+    time: Res<Time>,
+    mut timer: ResMut<SplashTimer>,
+    asset_server: Res<AssetServer>,
+    mut splash_query: Query<Entity, With<SplashScreen>>,
+    mut has_loaded_map: Local<bool>,
+) {
+    timer.0.tick(time.delta());
+
+    if timer.0.finished() && !*has_loaded_map {
+        // Despawn splash screen
+        for entity in splash_query.iter_mut() {
+            commands.entity(entity).despawn_recursive();
+        }
+
+        // Load LDtk map
+        info!("Loading LDtk map: test-map.ldtk");
+        let map_handle = asset_server.load("test-map.ldtk");
+        info!("Map handle created: {:?}", map_handle);
+
+        commands.spawn(LdtkWorldBundle {
+            ldtk_handle: map_handle.into(),
+            ..Default::default()
+        });
+
+        info!("Scene setup complete.");
+        *has_loaded_map = true;
+    }
 }


### PR DESCRIPTION
Introduce a splash screen that displays during the initial loading phase of the game. Implement a timer to control the duration of the splash screen and ensure it despawns once the level is fully loaded. Additionally, include necessary package dependencies for the splash screen functionality.