### PR TITLE
Add autolayouts for grass, dirt, and sand

### DIFF
--- a/assets/autolayout.aseprite
+++ b/assets/autolayout.aseprite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:593593392bd250ac45d897903328e984084d6d76bd91a07751b3bfed3166147e
-size 88366
+oid sha256:8b90a6c3c7cc2f073bd4a79d11987a17478de1a8765a76c07a2dd7a8bc0c70dc
+size 112338

--- a/assets/dirt1.png
+++ b/assets/dirt1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25ac8288a0a989ad4ba535feab655963ee43ee95cb8b2114175515aa48c2e2ee
+size 10462

--- a/assets/grass1.png
+++ b/assets/grass1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9811ac5397c1f931399545ebf2c4e5c463c16a745ef184ecd96be2ed3540bb23
+size 10424

--- a/src/components/entities.rs
+++ b/src/components/entities.rs
@@ -149,11 +149,11 @@ impl Plugin for EntitiesPlugin {
             .register_ldtk_entity::<QuarryBundle>("Quarry")
             .register_ldtk_entity::<ChestBundle>("Chest")
             .register_ldtk_entity::<DoorBundle>("Door")
-            .register_ldtk_int_cell::<ForestBundle>(1)
-            .register_ldtk_int_cell::<MudBundle>(2)
-            .register_ldtk_int_cell::<ConcreteBundle>(3)
-            .register_ldtk_int_cell::<WallBundle>(4)
-            .register_ldtk_int_cell::<PathBundle>(5)
-            .register_ldtk_int_cell::<WaterBundle>(6);
+            .register_ldtk_int_cell_for_layer::<ForestBundle>("IntGrid1", 1)
+            .register_ldtk_int_cell_for_layer::<MudBundle>("IntGrid1", 2)
+            .register_ldtk_int_cell_for_layer::<ConcreteBundle>("IntGrid1", 3)
+            .register_ldtk_int_cell_for_layer::<WallBundle>("IntGrid1", 4)
+            .register_ldtk_int_cell_for_layer::<PathBundle>("IntGrid1", 5)
+            .register_ldtk_int_cell_for_layer::<WaterBundle>("IntGrid1", 6);
     }
 }

--- a/src/systems/scene.rs
+++ b/src/systems/scene.rs
@@ -107,6 +107,8 @@ fn splash_screen_system(
             ..Default::default()
         });
 
+        info!("Spawned Ldtk world bundle ...");
+
         map_state.requested = true;
         // The splash screen will now stay visible until the level is loaded
     }


### PR DESCRIPTION
Implement autolayouts for terrain types, enhancing the registration of entities in the plugin. Update file references to accommodate new layouts.